### PR TITLE
fixing tutorial cards

### DIFF
--- a/static/css/site.css
+++ b/static/css/site.css
@@ -717,8 +717,6 @@ aside.content-panel {
 }
 
 .tutorial-card {
-  width: 426px;
-  /* max-width: 480px; */
   background-color: var(--blk);
   border: 1px solid var(--blu);
   border-radius: 8px;


### PR DESCRIPTION
Tutorial cards are overflowing, because of the fixe `width` applied on the `tutorial-card` class.

<img width="871" height="779" alt="image" src="https://github.com/user-attachments/assets/f1be89ff-4b93-4926-85f7-830c1f5f61a7" />

Removing the `width` will correctly repect the parent's `grid` container: 

<img width="1153" height="687" alt="image" src="https://github.com/user-attachments/assets/4f8c154f-c728-41f8-af2c-4e6768b082f4" />
